### PR TITLE
Add food & drink properties to all fruits

### DIFF
--- a/assets/prefabs/Blueberry/Blueberry.prefab
+++ b/assets/prefabs/Blueberry/Blueberry.prefab
@@ -5,9 +5,16 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Blueberry",
-    "stackId": "AdditionalFruits:Blueberry"
+    "stackId": "AdditionalFruits:Blueberry",
+    "consumedOnUse": true
   },
   "SeedDefinition": {
     "prefab": "AdditionalFruits:BlueberryBush"
+  },
+  "Food": {
+    "filling": 2
+  },
+  "Drink": {
+    "filling": 1
   }
 }

--- a/assets/prefabs/Cranberry/Cranberry.prefab
+++ b/assets/prefabs/Cranberry/Cranberry.prefab
@@ -5,7 +5,7 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Cranberry",
-    "stackId": "cranberry",
+    "stackId": "AdditionalFruits:Cranberry",
     "consumedOnUse": true
   },
   "SeedDefinition": {

--- a/assets/prefabs/Cranberry/Cranberry.prefab
+++ b/assets/prefabs/Cranberry/Cranberry.prefab
@@ -5,9 +5,16 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Cranberry",
-    "stackId": "cranberry"
+    "stackId": "cranberry",
+    "consumedOnUse": true
   },
   "SeedDefinition": {
     "prefab": "CranberryBush"
+  },
+  "Food": {
+    "filling": 1.5
+  },
+  "Drink": {
+    "filling": 1.5
   }
 }

--- a/assets/prefabs/Gojiberry/Gojiberry.prefab
+++ b/assets/prefabs/Gojiberry/Gojiberry.prefab
@@ -5,7 +5,7 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Gojiberry",
-    "stackId": "Gojiberry",
+    "stackId": "AdditionalFruits:Gojiberry",
     "consumedOnUse": true
   },
   "SeedDefinition": {

--- a/assets/prefabs/Gojiberry/Gojiberry.prefab
+++ b/assets/prefabs/Gojiberry/Gojiberry.prefab
@@ -5,9 +5,16 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Gojiberry",
-    "stackId": "Gojiberry"
+    "stackId": "Gojiberry",
+    "consumedOnUse": true
   },
   "SeedDefinition": {
     "prefab": "GojiberryBush"
+  },
+  "Food": {
+    "filling": 2
+  },
+  "Drink": {
+    "filling": 1
   }
 }

--- a/assets/prefabs/Gooseberry/Gooseberry.prefab
+++ b/assets/prefabs/Gooseberry/Gooseberry.prefab
@@ -5,9 +5,16 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Gooseberry",
-    "stackId": "Gooseberry"
+    "stackId": "Gooseberry",
+    "consumedOnUse": true
   },
   "SeedDefinition": {
     "prefab": "AdditionalFruits:GooseberryBush"
+  },
+  "Food": {
+    "filling": 2
+  },
+  "Drink": {
+    "filling": 1
   }
 }

--- a/assets/prefabs/Gooseberry/Gooseberry.prefab
+++ b/assets/prefabs/Gooseberry/Gooseberry.prefab
@@ -5,7 +5,7 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Gooseberry",
-    "stackId": "Gooseberry",
+    "stackId": "AdditionalFruits:Gooseberry",
     "consumedOnUse": true
   },
   "SeedDefinition": {

--- a/assets/prefabs/Guava/Guava.prefab
+++ b/assets/prefabs/Guava/Guava.prefab
@@ -5,7 +5,7 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Guava",
-    "stackId": "Guava",
+    "stackId": "AdditionalFruits:Guava",
     "consumedOnUse": true
   },
   "SeedDefinition": {

--- a/assets/prefabs/Guava/Guava.prefab
+++ b/assets/prefabs/Guava/Guava.prefab
@@ -5,9 +5,16 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Guava",
-    "stackId": "Guava"
+    "stackId": "Guava",
+    "consumedOnUse": true
   },
   "SeedDefinition": {
     "prefab": "AdditionalFruits:GuavaBush"
+  },
+  "Food": {
+    "filling": 3
+  },
+  "Drink": {
+    "filling": 1.5
   }
 }

--- a/assets/prefabs/Melon/Melon.prefab
+++ b/assets/prefabs/Melon/Melon.prefab
@@ -14,5 +14,11 @@
     "bud": "AdditionalFruits:MelonBud",
     "minGrowTime": 4000,
     "maxGrowTime": 7000
+  },
+  "Food": {
+    "filling": 3
+  },
+  "Drink": {
+    "filling": 1.5
   }
 }

--- a/assets/prefabs/Passionfruit/Passionfruit.prefab
+++ b/assets/prefabs/Passionfruit/Passionfruit.prefab
@@ -14,5 +14,11 @@
     "bud": "AdditionalFruits:PassionfruitBud",
     "minGrowTime": 4000,
     "maxGrowTime": 7000
+  },
+  "Food": {
+    "filling": 2.5
+  },
+  "Drink": {
+    "filling": 0.5
   }
 }

--- a/assets/prefabs/Peach/Peach.prefab
+++ b/assets/prefabs/Peach/Peach.prefab
@@ -5,7 +5,16 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Peach",
-    "stackId": "peach"
+    "stackId": "peach",
+    "consumedOnUse": true
   },
-  "SeedDefinition": {}
+  "Food": {
+    "filling": 2.5
+  },
+  "Drink": {
+    "filling": 0.5
+  },
+  "SeedDefinition": {
+    "prefab": "AdditionalFruits:PeachBush"
+  }
 }

--- a/assets/prefabs/Peach/Peach.prefab
+++ b/assets/prefabs/Peach/Peach.prefab
@@ -5,7 +5,7 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Peach",
-    "stackId": "peach",
+    "stackId": "AdditionalFruits:Peach",
     "consumedOnUse": true
   },
   "Food": {

--- a/assets/prefabs/Pineapple/Pineapple.prefab
+++ b/assets/prefabs/Pineapple/Pineapple.prefab
@@ -5,7 +5,14 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Pineapple",
-    "stackId": "Pineapple"
+    "stackId": "Pineapple",
+    "consumedOnUse": true
+  },
+  "Food": {
+    "filling": 3.5
+  },
+  "Drink": {
+    "filling": 1
   },
   "SeedDefinition": {
     "prefab": "AdditionalFruits:PineappleBush"

--- a/assets/prefabs/Pineapple/Pineapple.prefab
+++ b/assets/prefabs/Pineapple/Pineapple.prefab
@@ -5,7 +5,7 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Pineapple",
-    "stackId": "Pineapple",
+    "stackId": "AdditionalFruits:Pineapple",
     "consumedOnUse": true
   },
   "Food": {

--- a/assets/prefabs/Raspberry/Raspberry.prefab
+++ b/assets/prefabs/Raspberry/Raspberry.prefab
@@ -5,7 +5,7 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Raspberry",
-    "stackId": "Raspberry",
+    "stackId": "AdditionalFruits:Raspberry",
     "consumedOnUse": true
   },
   "SeedDefinition": {

--- a/assets/prefabs/Raspberry/Raspberry.prefab
+++ b/assets/prefabs/Raspberry/Raspberry.prefab
@@ -5,9 +5,16 @@
   },
   "Item": {
     "icon": "AdditionalFruits:Raspberry",
-    "stackId": "Raspberry"
+    "stackId": "Raspberry",
+    "consumedOnUse": true
   },
   "SeedDefinition": {
     "prefab": "AdditionalFruits:RaspberryBush"
+  },
+  "Food": {
+    "filling": 2
+  },
+  "Drink": {
+    "filling": 1
   }
 }

--- a/assets/prefabs/Strawberry/Strawberry.prefab
+++ b/assets/prefabs/Strawberry/Strawberry.prefab
@@ -5,9 +5,16 @@
   },
   "Item": {
     "icon": "AdditionalFruits:strawberry",
-    "stackId": "Strawberry"
+    "stackId": "Strawberry",
+    "consumedOnUse": true
   },
   "SeedDefinition": {
     "prefab": "AdditionalFruits:StrawberryBush"
+  },
+  "Food": {
+    "filling": 2
+  },
+  "Drink": {
+    "filling": 1
   }
 }

--- a/assets/prefabs/Strawberry/Strawberry.prefab
+++ b/assets/prefabs/Strawberry/Strawberry.prefab
@@ -5,7 +5,7 @@
   },
   "Item": {
     "icon": "AdditionalFruits:strawberry",
-    "stackId": "Strawberry",
+    "stackId": "AdditionalFruits:Strawberry",
     "consumedOnUse": true
   },
   "SeedDefinition": {

--- a/assets/prefabs/Tomato/Tomato.prefab
+++ b/assets/prefabs/Tomato/Tomato.prefab
@@ -12,10 +12,10 @@
     "type": "AdditionalFruits:Tomato"
   },
   "Food": {
-    "filling": 1
+    "filling": 1.5
   },
   "Drink": {
-    "filling": 1
+    "filling": 0.5
   },
   "ItemHelp": {
     "category": "Edible Flora",


### PR DESCRIPTION
Some fruits in this module could not be consumed by the player for hunger/thirst benefit. This PR adds these properties to all fruit, so that they are all consumable. Slight variations in benefit exist between all the fruits based on fruit size and water content.