### PR TITLE
fix: add missing mature guava bush

### DIFF
--- a/assets/blocks/Guava/MatureGuavaBush.block
+++ b/assets/blocks/Guava/MatureGuavaBush.block
@@ -1,0 +1,5 @@
+{
+  "basedOn": "AdditionalFruits:BaseBush",
+  "displayName": "Mature Guava Bush",
+  "tile": "AdditionalFruits:MatureGuavaBush"
+}


### PR DESCRIPTION
### How to test
1. Start CoreGameplay with AdditionalFruits activated
2. Cheat yourself a guava via `give guava`
3. Plant the guava by right-clicking on the ground with it in hand
4. Wait for the guava to become mature (full block size, but not carrying fruit yet)
5. Check that the block is visible in this stage (compare to without this fix where the bush disappears before entering fruiting stage